### PR TITLE
kapt2 isSubsignature workaround

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -75,7 +75,7 @@ ext.deps = [
 
     // Auto
     autovalue          : 'com.google.auto.value:auto-value:1.3',
-    autocommon         : 'com.google.auto:auto-common:0.7',
+    autocommon         : 'com.google.auto:auto-common:0.8',
     autoservice        : 'com.google.auto.service:auto-service:1.0-rc2',
 
     // Test dependencies

--- a/build.gradle
+++ b/build.gradle
@@ -8,14 +8,12 @@ ext.kotlin_version = '1.0.5'
 allprojects {
   repositories {
     jcenter()
-    maven { url "https://dl.bintray.com/kotlin/kotlin-eap" }
   }
 
   buildscript {
     repositories {
       jcenter()
       maven { url "https://plugins.gradle.org/m2/" }
-      maven { url "https://dl.bintray.com/kotlin/kotlin-eap" }
     }
 
     dependencies {

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ subprojects { project ->
   version = VERSION_NAME
 }
 
-ext.kotlin_version = '1.0.5-eap-66'
+ext.kotlin_version = '1.0.5'
 
 allprojects {
   repositories {
@@ -75,7 +75,7 @@ ext.deps = [
 
     // Auto
     autovalue          : 'com.google.auto.value:auto-value:1.3',
-    autocommon         : 'com.google.auto:auto-common:0.8',
+    autocommon         : 'com.google.auto:auto-common:0.7',
     autoservice        : 'com.google.auto.service:auto-service:1.0-rc2',
 
     // Test dependencies

--- a/paperparcel-compiler/src/main/java/paperparcel/AutoValueExtensionValidator.java
+++ b/paperparcel-compiler/src/main/java/paperparcel/AutoValueExtensionValidator.java
@@ -16,10 +16,9 @@
 
 package paperparcel;
 
-import com.google.auto.common.MoreElements;
 import com.google.auto.common.MoreTypes;
 import com.google.common.base.Optional;
-import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableList;
 import java.util.List;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ExecutableElement;
@@ -61,8 +60,8 @@ final class AutoValueExtensionValidator {
 
   private Optional<ExecutableElement> findWriteToParcel(TypeElement subject) {
     TypeMirror parcel = elements.getTypeElement("android.os.Parcel").asType();
-    ImmutableSet<ExecutableElement> methods =
-        MoreElements.getLocalAndInheritedMethods(subject, elements);
+    ImmutableList<ExecutableElement> methods =
+        Utils.getLocalAndInheritedMethods(elements, types, subject);
     for (ExecutableElement element : methods) {
       if (element.getSimpleName().contentEquals("writeToParcel")
           && MoreTypes.isTypeOf(void.class, element.getReturnType())

--- a/paperparcel-compiler/src/main/java/paperparcel/AutoValueExtensionValidator.java
+++ b/paperparcel-compiler/src/main/java/paperparcel/AutoValueExtensionValidator.java
@@ -62,7 +62,7 @@ final class AutoValueExtensionValidator {
   private Optional<ExecutableElement> findWriteToParcel(TypeElement subject) {
     TypeMirror parcel = elements.getTypeElement("android.os.Parcel").asType();
     ImmutableSet<ExecutableElement> methods =
-        MoreElements.getLocalAndInheritedMethods(subject, types, elements);
+        MoreElements.getLocalAndInheritedMethods(subject, elements);
     for (ExecutableElement element : methods) {
       if (element.getSimpleName().contentEquals("writeToParcel")
           && MoreTypes.isTypeOf(void.class, element.getReturnType())

--- a/paperparcel-compiler/src/main/java/paperparcel/PaperParcelAutoValueExtension.java
+++ b/paperparcel-compiler/src/main/java/paperparcel/PaperParcelAutoValueExtension.java
@@ -193,10 +193,9 @@ public class PaperParcelAutoValueExtension extends AutoValueExtension {
   private static boolean needsContentDescriptor(Context context) {
     ProcessingEnvironment env = context.processingEnvironment();
     TypeElement autoValueTypeElement = context.autoValueClass();
-    Types types = env.getTypeUtils();
     Elements elements = env.getElementUtils();
     ImmutableSet<ExecutableElement> methods =
-        MoreElements.getLocalAndInheritedMethods(autoValueTypeElement, types, elements);
+        MoreElements.getLocalAndInheritedMethods(autoValueTypeElement, elements);
     for (ExecutableElement element : methods) {
       if (element.getSimpleName().contentEquals("describeContents")
           && MoreTypes.isTypeOf(int.class, element.getReturnType())

--- a/paperparcel-compiler/src/main/java/paperparcel/PaperParcelAutoValueExtension.java
+++ b/paperparcel-compiler/src/main/java/paperparcel/PaperParcelAutoValueExtension.java
@@ -16,7 +16,6 @@
 
 package paperparcel;
 
-import com.google.auto.common.MoreElements;
 import com.google.auto.common.MoreTypes;
 import com.google.auto.service.AutoService;
 import com.google.auto.value.extension.AutoValueExtension;
@@ -194,8 +193,9 @@ public class PaperParcelAutoValueExtension extends AutoValueExtension {
     ProcessingEnvironment env = context.processingEnvironment();
     TypeElement autoValueTypeElement = context.autoValueClass();
     Elements elements = env.getElementUtils();
-    ImmutableSet<ExecutableElement> methods =
-        MoreElements.getLocalAndInheritedMethods(autoValueTypeElement, elements);
+    Types types = env.getTypeUtils();
+    ImmutableList<ExecutableElement> methods =
+        Utils.getLocalAndInheritedMethods(elements, types, autoValueTypeElement);
     for (ExecutableElement element : methods) {
       if (element.getSimpleName().contentEquals("describeContents")
           && MoreTypes.isTypeOf(int.class, element.getReturnType())

--- a/paperparcel-compiler/src/main/java/paperparcel/Utils.java
+++ b/paperparcel-compiler/src/main/java/paperparcel/Utils.java
@@ -104,9 +104,10 @@ final class Utils {
    * Returns a list of all non-private local and inherited methods (excluding methods
    * defined in {@link Object})
    */
+  @SuppressWarnings("UnusedParameters") // Will be used when using auto-common 0.8 (after kapt is fixed)
   static ImmutableList<ExecutableElement> getLocalAndInheritedMethods(
       Elements elements, Types types, TypeElement element) {
-    return FluentIterable.from(MoreElements.getLocalAndInheritedMethods(element, types, elements))
+    return FluentIterable.from(MoreElements.getLocalAndInheritedMethods(element, elements))
         .filter(new Predicate<ExecutableElement>() {
           @Override public boolean apply(ExecutableElement method) {
             // Filter out any methods defined in java.lang.Object as they are just

--- a/paperparcel-compiler/src/main/java/paperparcel/Utils.java
+++ b/paperparcel-compiler/src/main/java/paperparcel/Utils.java
@@ -104,9 +104,10 @@ final class Utils {
    * Returns a list of all non-private local and inherited methods (excluding methods
    * defined in {@link Object})
    */
-  @SuppressWarnings("UnusedParameters") // Will be used when using auto-common 0.8 (after kapt is fixed)
   static ImmutableList<ExecutableElement> getLocalAndInheritedMethods(
       Elements elements, Types types, TypeElement element) {
+    // TODO(brad): use the new overload for getLocalAndInheritedMethods once JetBrains has
+    // fixed https://youtrack.jetbrains.com/issue/KT-14613
     return FluentIterable.from(MoreElements.getLocalAndInheritedMethods(element, elements))
         .filter(new Predicate<ExecutableElement>() {
           @Override public boolean apply(ExecutableElement method) {


### PR DESCRIPTION
Works around https://youtrack.jetbrains.com/issue/KT-14613 by downgrading auto-common. This works because older versions of auto-common didn't rely on `Types#isSubsignature(...)` — it was only introduced to work around Eclipse bugs. Will upgrade again once the kapt issue is resolved. 