### PR TITLE
Use new overload for getLocalAndInheritedMethods

### DIFF
--- a/paperparcel-compiler/src/main/java/paperparcel/Utils.java
+++ b/paperparcel-compiler/src/main/java/paperparcel/Utils.java
@@ -106,9 +106,7 @@ final class Utils {
    */
   static ImmutableList<ExecutableElement> getLocalAndInheritedMethods(
       Elements elements, Types types, TypeElement element) {
-    // TODO(brad): use the new overload for getLocalAndInheritedMethods once JetBrains has
-    // fixed https://youtrack.jetbrains.com/issue/KT-14613
-    return FluentIterable.from(MoreElements.getLocalAndInheritedMethods(element, elements))
+    return FluentIterable.from(MoreElements.getLocalAndInheritedMethods(element, types, elements))
         .filter(new Predicate<ExecutableElement>() {
           @Override public boolean apply(ExecutableElement method) {
             // Filter out any methods defined in java.lang.Object as they are just


### PR DESCRIPTION
Replace deprecated method with a newer version. 