### PR TITLE
Fix primitive array as type argument crash

### DIFF
--- a/paperparcel-compiler/src/main/java/paperparcel/PaperParcelWriter.java
+++ b/paperparcel-compiler/src/main/java/paperparcel/PaperParcelWriter.java
@@ -364,6 +364,9 @@ final class PaperParcelWriter {
       ClassName className = (ClassName) typeName;
       adapterName = Joiner.on("_").join(className.simpleNames());
     }
+    if (typeName.isPrimitive()) {
+      adapterName = typeName.toString();
+    }
     if (adapterName == null) {
       throw new AssertionError();
     }

--- a/paperparcel-compiler/src/test/java/paperparcel/PaperParcelProcessorTests.java
+++ b/paperparcel-compiler/src/test/java/paperparcel/PaperParcelProcessorTests.java
@@ -2121,5 +2121,73 @@ public class PaperParcelProcessorTests {
         .in(source)
         .onLine(5);
   }
-  
+
+  @Test public void primitiveArrayAsTypeParameterTest() {
+    JavaFileObject source =
+        JavaFileObjects.forSourceString("test.Test", Joiner.on('\n').join(
+            "package test;",
+            "import android.os.Parcel;",
+            "import android.os.Parcelable;",
+            "import paperparcel.PaperParcel;",
+            "import java.util.List;",
+            "@PaperParcel",
+            "public class Test implements Parcelable {",
+            "  private List<int[]> value;",
+            "  public Test(List<int[]> value) {",
+            "    this.value = value;",
+            "  }",
+            "  public List<int[]> value() {",
+            "    return value;",
+            "  }",
+            "  @Override",
+            "  public int describeContents() {",
+            "    return 0;",
+            "  }",
+            "  @Override",
+            "  public void writeToParcel(Parcel dest, int flags) {",
+            "  }",
+            "}"
+        ));
+
+    JavaFileObject expected =
+        JavaFileObjects.forSourceString("test/PaperParcelTest", Joiner.on('\n').join(
+            "package test;",
+            "import android.os.Parcel;",
+            "import android.os.Parcelable;",
+            "import android.support.annotation.NonNull;",
+            "import java.util.List;",
+            "import javax.annotation.Generated;",
+            "import paperparcel.adapter.IntArrayAdapter;",
+            "import paperparcel.adapter.ListAdapter;",
+            GeneratedLines.GENERATED_ANNOTATION,
+            "final class PaperParcelTest {",
+            "  private static final ListAdapter<int[]> INT_ARRAY_LIST_ADAPTER = new ListAdapter<int[]>(IntArrayAdapter.INSTANCE);",
+            "  @NonNull",
+            "  static final Parcelable.Creator<Test> CREATOR = new Parcelable.Creator<Test>() {",
+            "    @Override",
+            "    public Test createFromParcel(Parcel in) {",
+            "      List<int[]> value = INT_ARRAY_LIST_ADAPTER.readFromParcel(in);",
+            "      Test data = new Test(value);",
+            "      return data;",
+            "    }",
+            "    @Override",
+            "    public Test[] newArray(int size) {",
+            "      return new Test[size];",
+            "    }",
+            "  };",
+            "  private PaperParcelTest() {",
+            "  }",
+            "  static void writeToParcel(@NonNull Test data, @NonNull Parcel dest, int flags) {",
+            "    INT_ARRAY_LIST_ADAPTER.writeToParcel(data.value(), dest, flags);",
+            "  }",
+            "}"
+        ));
+
+    assertAbout(javaSource()).that(source)
+        .processedWith(new PaperParcelProcessor())
+        .compilesWithoutError()
+        .and()
+        .generatesSources(expected);
+  }
+
 }


### PR DESCRIPTION
- Fixes crash when a field uses a primitive array as a type argument.
- Add a test.