### PR TITLE
Allows Java keywords to be used as field names if they are valid in Kotlin (e.g. “new”)

### DIFF
--- a/paperparcel-compiler/src/main/java/paperparcel/ErrorMessages.java
+++ b/paperparcel-compiler/src/main/java/paperparcel/ErrorMessages.java
@@ -93,6 +93,20 @@ final class ErrorMessages {
   static final String FIELD_TYPE_IS_INTERSECTION_TYPE =
       "PaperParcel does not support intersection field types.";
 
+  /* kapt errors */
+  static final String KAPT1_INCOMPATIBLE =
+      "PaperParcel is not compatible with legacy kapt. Please upgrade to kotlin 1.0.5 (or greater) "
+          + "and apply the 'kotlin-kapt' gradle plugin.";
+  static final String KAPT2_UNSTABLE_WARNING =
+      "kapt2 has been replaced with a newer version in kotlin 1.0.6 that is a lot more stable. It "
+          + "is highly recommended that you upgrade.";
+  static final String KAPT2_KT_13804 =
+      "PaperParcel is not compatible kotlin 1.0.4. Please upgrade to kotlin 1.0.5 (or greater)";
+  static final String KAPT2_INVALID_FIELD_NAME =
+      "Due to a bug in kapt, '%s' is not an allowable variable name. This bug is resolved in "
+          + "kotlin version 1.0.6. Please upgrade your kotlin version, or change this variable "
+          + "name.";
+
   /* AutoValue Extension errors */
   static final String MANUAL_IMPLEMENTATION_OF_CREATOR =
       "Manual implementation of a static Parcelable.Creator<T> CREATOR found in %s.";

--- a/paperparcel-compiler/src/main/java/paperparcel/UniqueNameSet.java
+++ b/paperparcel-compiler/src/main/java/paperparcel/UniqueNameSet.java
@@ -19,9 +19,11 @@ package paperparcel;
 
 import com.google.common.collect.Sets;
 import java.util.Set;
+import javax.lang.model.SourceVersion;
 
 /**
- * A collector for names to be used in the same namespace that should not conflict.
+ * A collector for names to be used in the same namespace that should not conflict. This class
+ * also ensures that the names are not Java keywords.
  */
 final class UniqueNameSet {
   private final Set<String> uniqueNames = Sets.newLinkedHashSet();
@@ -37,14 +39,19 @@ final class UniqueNameSet {
   }
 
   /**
-   * Generates a unique name using {@code base}. If {@code base} has not yet been added, it will be
-   * returned as-is. If your {@code base} is healthy, this will always return {@code base}.
+   * Generates a unique and valid name using {@code base}. If {@code base} has not yet been added,
+   * and is not a Java keyword; it will be returned as-is, otherwise it will have a differentiator
+   * appended.
    */
   String getUniqueName(CharSequence base) {
     String name = base.toString();
-    for (int differentiator = 1; !uniqueNames.add(name); differentiator++) {
+    for (int differentiator = 1; isInvalidName(name); differentiator++) {
       name = base.toString() + separator + differentiator;
     }
     return name;
+  }
+
+  private boolean isInvalidName(String name) {
+    return !uniqueNames.add(name) || SourceVersion.isKeyword(name);
   }
 }


### PR DESCRIPTION
This fix only works with kapt3 (kotlin 1.0.6+), but includes validation for kapt2 users with a helpful error message.
Fixes #137.