### PR TITLE
Remove restriction where a PaperParcel class cannot extend another

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -30,7 +30,7 @@
 <p>Using PaperParcel is easy, the API is extemely minimal. Let's look at an example:</p>
 
 <div class="highlight highlight-source-java"><pre><span class="pl-k">@PaperParcel</span> <span class="pl-c">// (1)</span>
-<span class="pl-k">public</span> <span class="pl-k">class</span> <span class="pl-en">User</span> <span class="pl-k">implements</span> <span class="pl-e">Parcelable</span> {
+<span class="pl-k">public</span> <span class="pl-k">final</span> <span class="pl-k">class</span> <span class="pl-en">User</span> <span class="pl-k">implements</span> <span class="pl-e">Parcelable</span> {
   <span class="pl-k">public</span> <span class="pl-k">static</span> <span class="pl-k">final</span> <span class="pl-k">Creator&lt;<span class="pl-smi">User</span>&gt;</span> <span class="pl-c1">CREATOR</span> <span class="pl-k">=</span> <span class="pl-smi">PaperParcelUser</span><span class="pl-c1"><span class="pl-k">.</span>CREATOR</span>; <span class="pl-c">// (2)</span>
 
   <span class="pl-k">long</span> id; <span class="pl-c">// (3)</span>

--- a/examples/benchmark-demo/README.md
+++ b/examples/benchmark-demo/README.md
@@ -1,11 +1,11 @@
 # Benchmark-demo
 
-This is a benchmark app that demonstrates that [PaperParcel](http://grandstaish.github.io/paperparcel/) is the fastest and lightest parcelling library available. Although performance isn't the primary value proposition for PaperParcel, it's nice to show that the generated code is really fast. 
+This is a benchmark app that demonstrates that [PaperParcel](http://grandstaish.github.io/paperparcel/) is the fastest parcelling library available. Although performance isn't the primary value proposition for PaperParcel, it's nice to show that the generated code is really fast.
 
 This demo also uses separate packages for the model classes for each processor so that the total number of generated method references can be easily compared. The results are as follows:
 - [AutoValue: Parcel Extension](https://github.com/rharter/auto-value-parcel) (216<sup>1</sup> + 0 library method references<sup>2</sup>)
-- [Parceler](http://parceler.org/) (70 methods + 607 library method references<sup>2</sup>)
-- [PaperParcel](http://grandstaish.github.io/paperparcel/) (60 methods + 187 library method references<sup>2</sup>)
+- [Parceler](http://parceler.org/) (104 methods + 607 library method references<sup>2</sup>)
+- [PaperParcel](http://grandstaish.github.io/paperparcel/) (94 methods + 194 library method references<sup>2</sup>)
 
 The code in this demonstration is mostly copied from [LoganSquare](https://github.com/bluelinelabs/LoganSquare/)'s benchmark demo app — so shout-out to [bluelinelabs](http://bluelinelabs.com/) for the code!
 

--- a/examples/benchmark-demo/src/main/java/nz/bradcampbell/benchmarkdemo/model/paperparcel/Friend.java
+++ b/examples/benchmark-demo/src/main/java/nz/bradcampbell/benchmarkdemo/model/paperparcel/Friend.java
@@ -21,11 +21,26 @@ import android.os.Parcelable;
 import paperparcel.PaperParcel;
 
 @PaperParcel
-public class Friend implements Parcelable {
+public final class Friend implements Parcelable {
   public static final Parcelable.Creator<Friend> CREATOR = PaperParcelFriend.CREATOR;
 
-  public int id;
-  public String name;
+  private final int id;
+  private final String name;
+
+  public Friend(
+      int id,
+      String name) {
+    this.id = id;
+    this.name = name;
+  }
+
+  public int getId() {
+    return id;
+  }
+
+  public String getName() {
+    return name;
+  }
 
   @Override public int describeContents() {
     return 0;

--- a/examples/benchmark-demo/src/main/java/nz/bradcampbell/benchmarkdemo/model/paperparcel/Image.java
+++ b/examples/benchmark-demo/src/main/java/nz/bradcampbell/benchmarkdemo/model/paperparcel/Image.java
@@ -21,13 +21,40 @@ import android.os.Parcelable;
 import paperparcel.PaperParcel;
 
 @PaperParcel
-public class Image implements Parcelable {
+public final class Image implements Parcelable {
   public static final Creator<Image> CREATOR = PaperParcelImage.CREATOR;
 
-  public String id;
-  public String format;
-  public String url;
-  public String description;
+  private final String id;
+  private final String format;
+  private final String url;
+  private final String description;
+
+  public Image(
+      String id,
+      String format,
+      String url,
+      String description) {
+    this.id = id;
+    this.format = format;
+    this.url = url;
+    this.description = description;
+  }
+
+  public String getId() {
+    return id;
+  }
+
+  public String getFormat() {
+    return format;
+  }
+
+  public String getUrl() {
+    return url;
+  }
+
+  public String getDescription() {
+    return description;
+  }
 
   @Override public int describeContents() {
     return 0;

--- a/examples/benchmark-demo/src/main/java/nz/bradcampbell/benchmarkdemo/model/paperparcel/Name.java
+++ b/examples/benchmark-demo/src/main/java/nz/bradcampbell/benchmarkdemo/model/paperparcel/Name.java
@@ -21,11 +21,26 @@ import android.os.Parcelable;
 import paperparcel.PaperParcel;
 
 @PaperParcel
-public class Name implements Parcelable {
+public final class Name implements Parcelable {
   public static final Parcelable.Creator<Name> CREATOR = PaperParcelName.CREATOR;
 
-  public String first;
-  public String last;
+  public final String first;
+  public final String last;
+
+  public Name(
+      String first,
+      String last) {
+    this.first = first;
+    this.last = last;
+  }
+
+  public String getFirst() {
+    return first;
+  }
+
+  public String getLast() {
+    return last;
+  }
 
   @Override public int describeContents() {
     return 0;

--- a/examples/benchmark-demo/src/main/java/nz/bradcampbell/benchmarkdemo/model/paperparcel/PaperParcelResponse.java
+++ b/examples/benchmark-demo/src/main/java/nz/bradcampbell/benchmarkdemo/model/paperparcel/PaperParcelResponse.java
@@ -24,12 +24,33 @@ import java.util.List;
 import paperparcel.PaperParcel;
 
 @PaperParcel
-public class PaperParcelResponse implements Parcelable {
+public final class PaperParcelResponse implements Parcelable {
   public static final Creator<PaperParcelResponse> CREATOR = PaperParcelPaperParcelResponse.CREATOR;
 
-  public List<User> users;
-  public String status;
-  @SerializedName("is_real_json") public boolean isRealJson;
+  private final List<User> users;
+  private final String status;
+  @SerializedName("is_real_json") private final boolean isRealJson;
+
+  public PaperParcelResponse(
+      List<User> users,
+      String status,
+      boolean isRealJson) {
+    this.users = users;
+    this.status = status;
+    this.isRealJson = isRealJson;
+  }
+
+  public List<User> getUsers() {
+    return users;
+  }
+
+  public String getStatus() {
+    return status;
+  }
+
+  public boolean isRealJson() {
+    return isRealJson;
+  }
 
   @Override public int describeContents() {
     return 0;

--- a/examples/benchmark-demo/src/main/java/nz/bradcampbell/benchmarkdemo/model/paperparcel/User.java
+++ b/examples/benchmark-demo/src/main/java/nz/bradcampbell/benchmarkdemo/model/paperparcel/User.java
@@ -24,32 +24,173 @@ import java.util.List;
 import paperparcel.PaperParcel;
 
 @PaperParcel
-public class User implements Parcelable {
+public final class User implements Parcelable {
   public static final Parcelable.Creator<User> CREATOR = PaperParcelUser.CREATOR;
 
-  public String id;
-  public int index;
-  public String guid;
-  @SerializedName("is_active") public boolean isActive;
-  public String balance;
-  @SerializedName("picture") public String pictureUrl;
-  public int age;
-  public Name name;
-  public String company;
-  public String email;
-  public String address;
-  public String about;
-  public String registered;
-  public double latitude;
-  public double longitude;
-  public List<String> tags;
-  public List<Integer> range;
-  public List<Friend> friends;
-  public List<Image> images;
-  public String greeting;
-  @SerializedName("favorite_fruit") public String favoriteFruit;
-  @SerializedName("eye_color") public String eyeColor;
-  public String phone;
+  private final String id;
+  private final int index;
+  private final String guid;
+  @SerializedName("is_active") private final boolean isActive;
+  private final String balance;
+  @SerializedName("picture") private final String pictureUrl;
+  private final int age;
+  private final Name name;
+  private final String company;
+  private final String email;
+  private final String address;
+  private final String about;
+  private final String registered;
+  private final double latitude;
+  private final double longitude;
+  private final List<String> tags;
+  private final List<Integer> range;
+  private final List<Friend> friends;
+  private final List<Image> images;
+  private final String greeting;
+  @SerializedName("favorite_fruit") private final String favoriteFruit;
+  @SerializedName("eye_color") private final String eyeColor;
+  private final String phone;
+
+  public User(
+      String id,
+      int index,
+      String guid,
+      boolean isActive,
+      String balance,
+      String pictureUrl,
+      int age,
+      Name name,
+      String company,
+      String email,
+      String address,
+      String about,
+      String registered,
+      double latitude,
+      double longitude,
+      List<String> tags,
+      List<Integer> range,
+      List<Friend> friends,
+      List<Image> images,
+      String greeting,
+      String favoriteFruit,
+      String eyeColor,
+      String phone) {
+    this.id = id;
+    this.index = index;
+    this.guid = guid;
+    this.isActive = isActive;
+    this.balance = balance;
+    this.pictureUrl = pictureUrl;
+    this.age = age;
+    this.name = name;
+    this.company = company;
+    this.email = email;
+    this.address = address;
+    this.about = about;
+    this.registered = registered;
+    this.latitude = latitude;
+    this.longitude = longitude;
+    this.tags = tags;
+    this.range = range;
+    this.friends = friends;
+    this.images = images;
+    this.greeting = greeting;
+    this.favoriteFruit = favoriteFruit;
+    this.eyeColor = eyeColor;
+    this.phone = phone;
+  }
+
+  public String getId() {
+    return id;
+  }
+
+  public int getIndex() {
+    return index;
+  }
+
+  public String getGuid() {
+    return guid;
+  }
+
+  public boolean isActive() {
+    return isActive;
+  }
+
+  public String getBalance() {
+    return balance;
+  }
+
+  public String getPictureUrl() {
+    return pictureUrl;
+  }
+
+  public int getAge() {
+    return age;
+  }
+
+  public Name getName() {
+    return name;
+  }
+
+  public String getCompany() {
+    return company;
+  }
+
+  public String getEmail() {
+    return email;
+  }
+
+  public String getAddress() {
+    return address;
+  }
+
+  public String getAbout() {
+    return about;
+  }
+
+  public String getRegistered() {
+    return registered;
+  }
+
+  public double getLatitude() {
+    return latitude;
+  }
+
+  public double getLongitude() {
+    return longitude;
+  }
+
+  public List<String> getTags() {
+    return tags;
+  }
+
+  public List<Integer> getRange() {
+    return range;
+  }
+
+  public List<Friend> getFriends() {
+    return friends;
+  }
+
+  public List<Image> getImages() {
+    return images;
+  }
+
+  public String getGreeting() {
+    return greeting;
+  }
+
+  public String getFavoriteFruit() {
+    return favoriteFruit;
+  }
+
+  public String getEyeColor() {
+    return eyeColor;
+  }
+
+  public String getPhone() {
+    return phone;
+  }
 
   @Override public int describeContents() {
     return 0;

--- a/examples/benchmark-demo/src/main/java/nz/bradcampbell/benchmarkdemo/model/parceler/Friend.java
+++ b/examples/benchmark-demo/src/main/java/nz/bradcampbell/benchmarkdemo/model/parceler/Friend.java
@@ -17,9 +17,26 @@
 package nz.bradcampbell.benchmarkdemo.model.parceler;
 
 import org.parceler.Parcel;
+import org.parceler.ParcelConstructor;
 
-@Parcel
-public class Friend {
-  public int id;
-  public String name;
+@Parcel(Parcel.Serialization.BEAN)
+public final class Friend {
+  private final int id;
+  private final String name;
+
+  @ParcelConstructor
+  public Friend(
+      int id,
+      String name) {
+    this.id = id;
+    this.name = name;
+  }
+
+  public int getId() {
+    return id;
+  }
+
+  public String getName() {
+    return name;
+  }
 }

--- a/examples/benchmark-demo/src/main/java/nz/bradcampbell/benchmarkdemo/model/parceler/Image.java
+++ b/examples/benchmark-demo/src/main/java/nz/bradcampbell/benchmarkdemo/model/parceler/Image.java
@@ -17,11 +17,40 @@
 package nz.bradcampbell.benchmarkdemo.model.parceler;
 
 import org.parceler.Parcel;
+import org.parceler.ParcelConstructor;
 
-@Parcel
-public class Image {
-  public String id;
-  public String format;
-  public String url;
-  public String description;
+@Parcel(Parcel.Serialization.BEAN)
+public final class Image {
+  private final String id;
+  private final String format;
+  private final String url;
+  private final String description;
+
+  @ParcelConstructor
+  public Image(
+      String id,
+      String format,
+      String url,
+      String description) {
+    this.id = id;
+    this.format = format;
+    this.url = url;
+    this.description = description;
+  }
+
+  public String getId() {
+    return id;
+  }
+
+  public String getFormat() {
+    return format;
+  }
+
+  public String getUrl() {
+    return url;
+  }
+
+  public String getDescription() {
+    return description;
+  }
 }

--- a/examples/benchmark-demo/src/main/java/nz/bradcampbell/benchmarkdemo/model/parceler/Name.java
+++ b/examples/benchmark-demo/src/main/java/nz/bradcampbell/benchmarkdemo/model/parceler/Name.java
@@ -17,9 +17,26 @@
 package nz.bradcampbell.benchmarkdemo.model.parceler;
 
 import org.parceler.Parcel;
+import org.parceler.ParcelConstructor;
 
-@Parcel
-public class Name {
-  public String first;
-  public String last;
+@Parcel(Parcel.Serialization.BEAN)
+public final class Name {
+  private final String first;
+  private final String last;
+
+  @ParcelConstructor
+  public Name(
+      String first,
+      String last) {
+    this.first = first;
+    this.last = last;
+  }
+
+  public String getFirst() {
+    return first;
+  }
+
+  public String getLast() {
+    return last;
+  }
 }

--- a/examples/benchmark-demo/src/main/java/nz/bradcampbell/benchmarkdemo/model/parceler/ParcelerResponse.java
+++ b/examples/benchmark-demo/src/main/java/nz/bradcampbell/benchmarkdemo/model/parceler/ParcelerResponse.java
@@ -19,10 +19,33 @@ package nz.bradcampbell.benchmarkdemo.model.parceler;
 import com.google.gson.annotations.SerializedName;
 import java.util.List;
 import org.parceler.Parcel;
+import org.parceler.ParcelConstructor;
 
-@Parcel
-public class ParcelerResponse {
-  public List<User> users;
-  public String status;
-  @SerializedName("is_real_json") public boolean isRealJson;
+@Parcel(Parcel.Serialization.BEAN)
+public final class ParcelerResponse {
+  private final List<User> users;
+  private final String status;
+  @SerializedName("is_real_json") private final boolean isRealJson;
+
+  @ParcelConstructor
+  public ParcelerResponse(
+      List<User> users,
+      String status,
+      boolean isRealJson) {
+    this.users = users;
+    this.status = status;
+    this.isRealJson = isRealJson;
+  }
+
+  public List<User> getUsers() {
+    return users;
+  }
+
+  public String getStatus() {
+    return status;
+  }
+
+  public boolean isIsRealJson() {
+    return isRealJson;
+  }
 }

--- a/examples/benchmark-demo/src/main/java/nz/bradcampbell/benchmarkdemo/model/parceler/User.java
+++ b/examples/benchmark-demo/src/main/java/nz/bradcampbell/benchmarkdemo/model/parceler/User.java
@@ -19,30 +19,173 @@ package nz.bradcampbell.benchmarkdemo.model.parceler;
 import com.google.gson.annotations.SerializedName;
 import java.util.List;
 import org.parceler.Parcel;
+import org.parceler.ParcelConstructor;
 
-@Parcel
-public class User {
-  public String id;
-  public int index;
-  public String guid;
-  @SerializedName("is_active") public boolean isActive;
-  public String balance;
-  @SerializedName("picture") public String pictureUrl;
-  public int age;
-  public Name name;
-  public String company;
-  public String email;
-  public String address;
-  public String about;
-  public String registered;
-  public double latitude;
-  public double longitude;
-  public List<String> tags;
-  public List<Integer> range;
-  public List<Friend> friends;
-  public List<Image> images;
-  public String greeting;
-  @SerializedName("favorite_fruit") public String favoriteFruit;
-  @SerializedName("eye_color") public String eyeColor;
-  public String phone;
+@Parcel(Parcel.Serialization.BEAN)
+public final class User {
+  private final String id;
+  private final int index;
+  private final String guid;
+  @SerializedName("is_active") private final boolean isActive;
+  private final String balance;
+  @SerializedName("picture") private final String pictureUrl;
+  private final int age;
+  private final Name name;
+  private final String company;
+  private final String email;
+  private final String address;
+  private final String about;
+  private final String registered;
+  private final double latitude;
+  private final double longitude;
+  private final List<String> tags;
+  private final List<Integer> range;
+  private final List<Friend> friends;
+  private final List<Image> images;
+  private final String greeting;
+  @SerializedName("favorite_fruit") private final String favoriteFruit;
+  @SerializedName("eye_color") private final String eyeColor;
+  private final String phone;
+
+  @ParcelConstructor
+  public User(
+      String id,
+      int index,
+      String guid,
+      boolean isActive,
+      String balance,
+      String pictureUrl,
+      int age,
+      Name name,
+      String company,
+      String email,
+      String address,
+      String about,
+      String registered,
+      double latitude,
+      double longitude,
+      List<String> tags,
+      List<Integer> range,
+      List<Friend> friends,
+      List<Image> images,
+      String greeting,
+      String favoriteFruit,
+      String eyeColor,
+      String phone) {
+    this.id = id;
+    this.index = index;
+    this.guid = guid;
+    this.isActive = isActive;
+    this.balance = balance;
+    this.pictureUrl = pictureUrl;
+    this.age = age;
+    this.name = name;
+    this.company = company;
+    this.email = email;
+    this.address = address;
+    this.about = about;
+    this.registered = registered;
+    this.latitude = latitude;
+    this.longitude = longitude;
+    this.tags = tags;
+    this.range = range;
+    this.friends = friends;
+    this.images = images;
+    this.greeting = greeting;
+    this.favoriteFruit = favoriteFruit;
+    this.eyeColor = eyeColor;
+    this.phone = phone;
+  }
+
+  public String getId() {
+    return id;
+  }
+
+  public int getIndex() {
+    return index;
+  }
+
+  public String getGuid() {
+    return guid;
+  }
+
+  public boolean isIsActive() {
+    return isActive;
+  }
+
+  public String getBalance() {
+    return balance;
+  }
+
+  public String getPictureUrl() {
+    return pictureUrl;
+  }
+
+  public int getAge() {
+    return age;
+  }
+
+  public Name getName() {
+    return name;
+  }
+
+  public String getCompany() {
+    return company;
+  }
+
+  public String getEmail() {
+    return email;
+  }
+
+  public String getAddress() {
+    return address;
+  }
+
+  public String getAbout() {
+    return about;
+  }
+
+  public String getRegistered() {
+    return registered;
+  }
+
+  public double getLatitude() {
+    return latitude;
+  }
+
+  public double getLongitude() {
+    return longitude;
+  }
+
+  public List<String> getTags() {
+    return tags;
+  }
+
+  public List<Integer> getRange() {
+    return range;
+  }
+
+  public List<Friend> getFriends() {
+    return friends;
+  }
+
+  public List<Image> getImages() {
+    return images;
+  }
+
+  public String getGreeting() {
+    return greeting;
+  }
+
+  public String getFavoriteFruit() {
+    return favoriteFruit;
+  }
+
+  public String getEyeColor() {
+    return eyeColor;
+  }
+
+  public String getPhone() {
+    return phone;
+  }
 }

--- a/examples/benchmark-demo/src/main/java/nz/bradcampbell/benchmarkdemo/model/serializable/Friend.java
+++ b/examples/benchmark-demo/src/main/java/nz/bradcampbell/benchmarkdemo/model/serializable/Friend.java
@@ -18,7 +18,22 @@ package nz.bradcampbell.benchmarkdemo.model.serializable;
 
 import java.io.Serializable;
 
-public class Friend implements Serializable {
-  public int id;
-  public String name;
+public final class Friend implements Serializable {
+  private final int id;
+  private final String name;
+
+  public Friend(
+      int id,
+      String name) {
+    this.id = id;
+    this.name = name;
+  }
+
+  public int getId() {
+    return id;
+  }
+
+  public String getName() {
+    return name;
+  }
 }

--- a/examples/benchmark-demo/src/main/java/nz/bradcampbell/benchmarkdemo/model/serializable/Image.java
+++ b/examples/benchmark-demo/src/main/java/nz/bradcampbell/benchmarkdemo/model/serializable/Image.java
@@ -18,9 +18,36 @@ package nz.bradcampbell.benchmarkdemo.model.serializable;
 
 import java.io.Serializable;
 
-public class Image implements Serializable {
-  public String id;
-  public String format;
-  public String url;
-  public String description;
+public final class Image implements Serializable {
+  private final String id;
+  private final String format;
+  private final String url;
+  private final String description;
+
+  public Image(
+      String id,
+      String format,
+      String url,
+      String description) {
+    this.id = id;
+    this.format = format;
+    this.url = url;
+    this.description = description;
+  }
+
+  public String getId() {
+    return id;
+  }
+
+  public String getFormat() {
+    return format;
+  }
+
+  public String getUrl() {
+    return url;
+  }
+
+  public String getDescription() {
+    return description;
+  }
 }

--- a/examples/benchmark-demo/src/main/java/nz/bradcampbell/benchmarkdemo/model/serializable/Name.java
+++ b/examples/benchmark-demo/src/main/java/nz/bradcampbell/benchmarkdemo/model/serializable/Name.java
@@ -18,7 +18,22 @@ package nz.bradcampbell.benchmarkdemo.model.serializable;
 
 import java.io.Serializable;
 
-public class Name implements Serializable {
-  public String first;
-  public String last;
+public final class Name implements Serializable {
+  private final String first;
+  private final String last;
+
+  public Name(
+      String first,
+      String last) {
+    this.first = first;
+    this.last = last;
+  }
+
+  public String getFirst() {
+    return first;
+  }
+
+  public String getLast() {
+    return last;
+  }
 }

--- a/examples/benchmark-demo/src/main/java/nz/bradcampbell/benchmarkdemo/model/serializable/SerializableResponse.java
+++ b/examples/benchmark-demo/src/main/java/nz/bradcampbell/benchmarkdemo/model/serializable/SerializableResponse.java
@@ -20,8 +20,29 @@ import com.google.gson.annotations.SerializedName;
 import java.io.Serializable;
 import java.util.List;
 
-public class SerializableResponse implements Serializable {
-  public List<User> users;
-  public String status;
-  @SerializedName("is_real_json") public boolean isRealJson;
+public final class SerializableResponse implements Serializable {
+  private final List<User> users;
+  private final String status;
+  @SerializedName("is_real_json") private final boolean isRealJson;
+
+  public SerializableResponse(
+      List<User> users,
+      String status,
+      boolean isRealJson) {
+    this.users = users;
+    this.status = status;
+    this.isRealJson = isRealJson;
+  }
+
+  public List<User> getUsers() {
+    return users;
+  }
+
+  public String getStatus() {
+    return status;
+  }
+
+  public boolean isRealJson() {
+    return isRealJson;
+  }
 }

--- a/examples/benchmark-demo/src/main/java/nz/bradcampbell/benchmarkdemo/model/serializable/User.java
+++ b/examples/benchmark-demo/src/main/java/nz/bradcampbell/benchmarkdemo/model/serializable/User.java
@@ -20,28 +20,169 @@ import com.google.gson.annotations.SerializedName;
 import java.io.Serializable;
 import java.util.List;
 
-public class User implements Serializable {
-  public String id;
-  public int index;
-  public String guid;
-  @SerializedName("is_active") public boolean isActive;
-  public String balance;
-  @SerializedName("picture") public String pictureUrl;
-  public int age;
-  public Name name;
-  public String company;
-  public String email;
-  public String address;
-  public String about;
-  public String registered;
-  public double latitude;
-  public double longitude;
-  public List<String> tags;
-  public List<Integer> range;
-  public List<Friend> friends;
-  public List<Image> images;
-  public String greeting;
-  @SerializedName("favorite_fruit") public String favoriteFruit;
-  @SerializedName("eye_color") public String eyeColor;
-  public String phone;
+public final class User implements Serializable {
+  private final String id;
+  private final int index;
+  private final String guid;
+  @SerializedName("is_active") private final boolean isActive;
+  private final String balance;
+  @SerializedName("picture") private final String pictureUrl;
+  private final int age;
+  private final Name name;
+  private final String company;
+  private final String email;
+  private final String address;
+  private final String about;
+  private final String registered;
+  private final double latitude;
+  private final double longitude;
+  private final List<String> tags;
+  private final List<Integer> range;
+  private final List<Friend> friends;
+  private final List<Image> images;
+  private final String greeting;
+  @SerializedName("favorite_fruit") private final String favoriteFruit;
+  @SerializedName("eye_color") private final String eyeColor;
+  private final String phone;
+
+  public User(
+      String id,
+      int index,
+      String guid,
+      boolean isActive,
+      String balance,
+      String pictureUrl,
+      int age,
+      Name name,
+      String company,
+      String email,
+      String address,
+      String about,
+      String registered,
+      double latitude,
+      double longitude,
+      List<String> tags,
+      List<Integer> range,
+      List<Friend> friends,
+      List<Image> images,
+      String greeting,
+      String favoriteFruit,
+      String eyeColor,
+      String phone) {
+    this.id = id;
+    this.index = index;
+    this.guid = guid;
+    this.isActive = isActive;
+    this.balance = balance;
+    this.pictureUrl = pictureUrl;
+    this.age = age;
+    this.name = name;
+    this.company = company;
+    this.email = email;
+    this.address = address;
+    this.about = about;
+    this.registered = registered;
+    this.latitude = latitude;
+    this.longitude = longitude;
+    this.tags = tags;
+    this.range = range;
+    this.friends = friends;
+    this.images = images;
+    this.greeting = greeting;
+    this.favoriteFruit = favoriteFruit;
+    this.eyeColor = eyeColor;
+    this.phone = phone;
+  }
+
+  public String getId() {
+    return id;
+  }
+
+  public int getIndex() {
+    return index;
+  }
+
+  public String getGuid() {
+    return guid;
+  }
+
+  public boolean isActive() {
+    return isActive;
+  }
+
+  public String getBalance() {
+    return balance;
+  }
+
+  public String getPictureUrl() {
+    return pictureUrl;
+  }
+
+  public int getAge() {
+    return age;
+  }
+
+  public Name getName() {
+    return name;
+  }
+
+  public String getCompany() {
+    return company;
+  }
+
+  public String getEmail() {
+    return email;
+  }
+
+  public String getAddress() {
+    return address;
+  }
+
+  public String getAbout() {
+    return about;
+  }
+
+  public String getRegistered() {
+    return registered;
+  }
+
+  public double getLatitude() {
+    return latitude;
+  }
+
+  public double getLongitude() {
+    return longitude;
+  }
+
+  public List<String> getTags() {
+    return tags;
+  }
+
+  public List<Integer> getRange() {
+    return range;
+  }
+
+  public List<Friend> getFriends() {
+    return friends;
+  }
+
+  public List<Image> getImages() {
+    return images;
+  }
+
+  public String getGreeting() {
+    return greeting;
+  }
+
+  public String getFavoriteFruit() {
+    return favoriteFruit;
+  }
+
+  public String getEyeColor() {
+    return eyeColor;
+  }
+
+  public String getPhone() {
+    return phone;
+  }
 }

--- a/examples/benchmark-demo/src/main/java/nz/bradcampbell/benchmarkdemo/parceltasks/PaperParcelTask.java
+++ b/examples/benchmark-demo/src/main/java/nz/bradcampbell/benchmarkdemo/parceltasks/PaperParcelTask.java
@@ -28,6 +28,6 @@ public class PaperParcelTask extends ParcelTask<PaperParcelResponse> {
     parcel.writeParcelable(response, 0);
     parcel.setDataPosition(0);
     PaperParcelResponse out = parcel.readParcelable(PaperParcelResponse.class.getClassLoader());
-    return out.users.size();
+    return out.getUsers().size();
   }
 }

--- a/examples/benchmark-demo/src/main/java/nz/bradcampbell/benchmarkdemo/parceltasks/ParcelerTask.java
+++ b/examples/benchmark-demo/src/main/java/nz/bradcampbell/benchmarkdemo/parceltasks/ParcelerTask.java
@@ -29,6 +29,6 @@ public class ParcelerTask extends ParcelTask<ParcelerResponse> {
     parcel.writeParcelable(Parcels.wrap(response), 0);
     parcel.setDataPosition(0);
     ParcelerResponse out = Parcels.unwrap(parcel.readParcelable(ParcelerResponse.class.getClassLoader()));
-    return out.users.size();
+    return out.getUsers().size();
   }
 }

--- a/examples/benchmark-demo/src/main/java/nz/bradcampbell/benchmarkdemo/parceltasks/SerializableTask.java
+++ b/examples/benchmark-demo/src/main/java/nz/bradcampbell/benchmarkdemo/parceltasks/SerializableTask.java
@@ -28,6 +28,6 @@ public class SerializableTask extends ParcelTask<SerializableResponse> {
     parcel.writeSerializable(response);
     parcel.setDataPosition(0);
     SerializableResponse out = (SerializableResponse) parcel.readSerializable();
-    return out.users.size();
+    return out.getUsers().size();
   }
 }

--- a/paperparcel-compiler/src/main/java/paperparcel/ErrorMessages.java
+++ b/paperparcel-compiler/src/main/java/paperparcel/ErrorMessages.java
@@ -66,8 +66,6 @@ final class ErrorMessages {
           + "arguments are matched with fields via their name and type.";
   static final String WILDCARD_IN_FIELD_TYPE =
       "Wildcard field types are not supported.";
-  static final String PAPERPARCEL_EXTENDS_PAPERPARCEL =
-      "One @PaperParcel class may not extend another.";
   static final String PAPERPARCEL_ON_ANNOTATION =
       "@PaperParcel may not be used to implement an annotation interface.";
   static final String PAPERPARCEL_ON_PRIVATE_CLASS =

--- a/paperparcel-compiler/src/main/java/paperparcel/PaperParcelValidator.java
+++ b/paperparcel-compiler/src/main/java/paperparcel/PaperParcelValidator.java
@@ -16,7 +16,6 @@
 
 package paperparcel;
 
-import com.google.auto.common.MoreElements;
 import com.google.auto.common.Visibility;
 import com.google.common.collect.ImmutableList;
 import java.lang.annotation.Annotation;
@@ -26,7 +25,6 @@ import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.Modifier;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.element.VariableElement;
-import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
 import javax.lang.model.util.Elements;
 import javax.lang.model.util.Types;
@@ -57,9 +55,6 @@ final class PaperParcelValidator {
     }
     if (!Utils.isParcelable(elements, types, element.asType())) {
       builder.addError(ErrorMessages.PAPERPARCEL_ON_NON_PARCELABLE);
-    }
-    if (ancestorIsPaperParcel(types, element)) {
-      builder.addError(ErrorMessages.PAPERPARCEL_EXTENDS_PAPERPARCEL);
     }
     if (implementsAnnotation(elements, types, element)) {
       builder.addError(ErrorMessages.PAPERPARCEL_ON_ANNOTATION);
@@ -115,19 +110,5 @@ final class PaperParcelValidator {
   private boolean implementsAnnotation(Elements elements, Types types, TypeElement type) {
     TypeMirror annotationType = elements.getTypeElement(Annotation.class.getName()).asType();
     return types.isAssignable(type.asType(), annotationType);
-  }
-
-  private boolean ancestorIsPaperParcel(Types types, TypeElement type) {
-    while (true) {
-      TypeMirror parentMirror = type.getSuperclass();
-      if (parentMirror.getKind() == TypeKind.NONE) {
-        return false;
-      }
-      TypeElement parentElement = (TypeElement) types.asElement(parentMirror);
-      if (MoreElements.isAnnotationPresent(parentElement, PaperParcel.class)) {
-        return true;
-      }
-      type = parentElement;
-    }
   }
 }


### PR DESCRIPTION
- Ensure non-final Parcelable types are parcelled using Parcel.readParcelable and Parcel.writeParcelable because it supports polymorphic types