### PR TITLE
Improve parameter get/set method matching

### DIFF
--- a/paperparcel-compiler/src/main/java/paperparcel/Strings.java
+++ b/paperparcel-compiler/src/main/java/paperparcel/Strings.java
@@ -18,14 +18,51 @@ package paperparcel;
 
 /** Utility methods for Strings */
 final class Strings {
+
   /**
    * Capitalizes the first character of {@code s}. If {@code s} is {@code null} or empty,
    * {@code s} is returned unmodified
    */
-  static String capitalizeFirstCharacter(String s) {
-    if (s == null || s.length() == 0) {
+  static String capitalizeAsciiOnly(String s) {
+    if (s == null || s.isEmpty()) {
       return s;
     }
-    return s.substring(0, 1).toUpperCase() + s.substring(1);
+    char c = s.charAt(0);
+    if (isLowerCaseAsciiOnly(c)) {
+      return Character.toUpperCase(c) + s.substring(1);
+    }
+    return s;
+  }
+
+  /**
+   * "fooBar" -> "FOOBar"
+   * "FooBar" -> "FOOBar"
+   * "foo" -> "FOO"
+   */
+  static String capitalizeFirstWordAsciiOnly(String s) {
+    if (s == null || s.isEmpty()) {
+      return s;
+    }
+    int secondWordStart = s.length();
+    for (int i = 1; i < s.length(); i++) {
+      if (!isLowerCaseAsciiOnly(s.charAt(i))) {
+        secondWordStart = i;
+        break;
+      }
+    }
+    return toUpperCaseAsciiOnly(s.substring(0, secondWordStart)) + s.substring(secondWordStart);
+  }
+
+  private static boolean isLowerCaseAsciiOnly(char c) {
+    return c >= 'a' && c <= 'z';
+  }
+
+  private static String toUpperCaseAsciiOnly(String s) {
+    StringBuilder builder = new StringBuilder(s.length());
+    for (int i = 0; i < s.length(); i++) {
+      char c = s.charAt(i);
+      builder.append(isLowerCaseAsciiOnly(c) ? Character.toUpperCase(c) : c);
+    }
+    return builder.toString();
   }
 }


### PR DESCRIPTION
- Supports properties that start with `is` or `has` where the prefix is omitted from the set method identifier.
- Supports single word acronym properties where the get/set method names have capitalised the acronym, e.g. `html` -> `getHTML()` and `setHTML()`.
- Exclude methods with type parameters from being considered as potential get/set methods for a property.
- Fixes #135.