### PR TITLE
Synchronize the write method cache

### DIFF
--- a/paperparcel-kotlin/src/main/java/paperparcel/PaperParcelable.kt
+++ b/paperparcel-kotlin/src/main/java/paperparcel/PaperParcelable.kt
@@ -20,9 +20,7 @@ interface PaperParcelable : Parcelable {
         val generatedClass = Class.forName(annotatedClass.implementationName)
         generatedClass
                 .getDeclaredMethod("writeToParcel", annotatedClass, Parcel::class.java, Int::class.javaPrimitiveType)
-                .apply {
-                  isAccessible = true
-                }
+                .apply { isAccessible = true }
       }
     }
     writeMethod.invoke(null, this, dest, flags)
@@ -34,7 +32,7 @@ interface PaperParcelable : Parcelable {
         return this
       }
       require(this != Any::class.java) {
-        "Cannot find @${PaperParcel::class.java.simpleName} on ${this@PaperParcelable.javaClass.name}."
+        "Cannot find @PaperParcel on ${this@PaperParcelable.javaClass.name}."
       }
       return superclass.annotatedClass
     }

--- a/paperparcel-kotlin/src/main/java/paperparcel/PaperParcelable.kt
+++ b/paperparcel-kotlin/src/main/java/paperparcel/PaperParcelable.kt
@@ -11,38 +11,38 @@ import java.lang.reflect.Method
  * @since 2.0
  */
 interface PaperParcelable : Parcelable {
-  private object Cache {
-    val writeMethods = mutableMapOf<Class<*>, Method>()
-  }
-
   override fun describeContents() = 0
 
   override fun writeToParcel(dest: Parcel, flags: Int) {
-    if (!Cache.writeMethods.containsKey(javaClass)) {
-      val annotatedClass = findAnnotatedClass(javaClass)
-      val generatedClass = Class.forName(implementationName(annotatedClass))
-      val args = arrayOf(annotatedClass, Parcel::class.java, Int::class.javaPrimitiveType)
-      val writeMethod = generatedClass.getDeclaredMethod("writeToParcel", *args)
-      writeMethod.isAccessible = true
-      Cache.writeMethods.put(javaClass, writeMethod)
+    val writeMethod: Method = synchronized(writeMethods) {
+      writeMethods.getOrPut(javaClass) {
+        val annotatedClass = javaClass.annotatedClass
+        val generatedClass = Class.forName(annotatedClass.implementationName)
+        generatedClass
+                .getDeclaredMethod("writeToParcel", annotatedClass, Parcel::class.java, Int::class.javaPrimitiveType)
+                .apply {
+                  isAccessible = true
+                }
+      }
     }
-    Cache.writeMethods[javaClass]!!.invoke(null, this, dest, flags)
+    writeMethod.invoke(null, this, dest, flags)
   }
 
-  private fun findAnnotatedClass(type: Class<*>): Class<*> {
-    if (type.isAnnotationPresent(PaperParcel::class.java)) {
-      return type
+  private val Class<*>.annotatedClass: Class<*>
+    get() {
+      if (isAnnotationPresent(PaperParcel::class.java)) {
+        return this
+      }
+      require(this != Any::class.java) {
+        "Cannot find @${PaperParcel::class.java.simpleName} on ${this@PaperParcelable.javaClass.name}."
+      }
+      return superclass.annotatedClass
     }
-    if (type == Any::class.java) {
-      throw IllegalArgumentException(
-          "Cannot find @${PaperParcel::class.java.simpleName} on ${javaClass.name}.")
-    }
-    return findAnnotatedClass(type.superclass)
-  }
 
-  private fun implementationName(type: Class<*>): String {
-    val packageName = type.`package`.name
-    val className = type.name.substring(packageName.length + 1).replace('$', '_')
-    return packageName + ".PaperParcel" + className
+  private val Class<*>.implementationName: String
+    get() = "${`package`.name}.PaperParcel${name.substring(`package`.name.length + 1).replace('$', '_')}"
+
+  private companion object {
+    val writeMethods = HashMap<Class<*>, Method>()
   }
 }

--- a/paperparcel-kotlin/src/main/java/paperparcel/PaperParcelable.kt
+++ b/paperparcel-kotlin/src/main/java/paperparcel/PaperParcelable.kt
@@ -14,7 +14,7 @@ interface PaperParcelable : Parcelable {
   override fun describeContents() = 0
 
   override fun writeToParcel(dest: Parcel, flags: Int) {
-    val writeMethod: Method = synchronized(writeMethods) {
+    val writeMethod = synchronized(writeMethods) {
       writeMethods.getOrPut(javaClass) {
         val annotatedClass = javaClass.annotatedClass
         val generatedClass = Class.forName(annotatedClass.implementationName)


### PR DESCRIPTION
Since there is no guarantee that parceling will not happen concurrently the write method cache must be synchronised to ensure thread safety.

I also converted some methods to properties. If you disapprove of these changes let me know and I'll revert them.