### PR TITLE
Configures stricter proguard rules

### DIFF
--- a/paperparcel-kotlin/proguard-rules.txt
+++ b/paperparcel-kotlin/proguard-rules.txt
@@ -1,5 +1,7 @@
--keep class **.PaperParcel* {
+-keepclassmembernames class **.PaperParcel* {
   static void writeToParcel(...);
 }
 
--keep @paperparcel.PaperParcel class *
+-keepnames class **.PaperParcel*
+
+-keepnames @paperparcel.PaperParcel class *


### PR DESCRIPTION
Prevents all PaperParcel classes being kept by proguard and instead keeps only the required methods and names.

I've tested this on 2 apps that use PaperParcel extensively with no issues.